### PR TITLE
Endpoint enum can now tke parameters

### DIFF
--- a/treetracker-core/Networking/APIClient/Endpoint.swift
+++ b/treetracker-core/Networking/APIClient/Endpoint.swift
@@ -1,5 +1,12 @@
 import Foundation
 
-enum Endpoint: String {
-    case messages = "messaging/message"
+enum Endpoint {
+    case messages
+
+    var rawValue: String {
+        switch self {
+        case .messages:
+            return "messaging/message"
+        }
+    }
 }


### PR DESCRIPTION
Endpoint enum no longer has a string value so that we can pass parameters. Instead we have a rawValue variable to compute and return the path.