### PR TITLE
APIService now handles empty data if expected using empty codable

### DIFF
--- a/treetracker-core/Networking/APIClient/APIService.swift
+++ b/treetracker-core/Networking/APIClient/APIService.swift
@@ -36,6 +36,12 @@ class APIService: APIServiceProtocol {
                     return
                 }
 
+                // If data is empty, but we expect it to be, complete successfully with EmptyCodable.
+                if data.isEmpty, let emptyCodable = EmptyCodable() as? Request.ResponseType {
+                    completion(.success(emptyCodable))
+                    return
+                }
+
                 do {
                     let decodedObject = try request.responseDecoder.decode(Request.ResponseType.self, from: data)
                     completion(.success(decodedObject))

--- a/treetracker-core/Networking/EmptyCodable.swift
+++ b/treetracker-core/Networking/EmptyCodable.swift
@@ -1,0 +1,10 @@
+//
+//  EmptyCodable.swift
+//  Treetracker-Core
+//
+//  Created by Alex Cornforth on 17/09/2023.
+//
+
+import Foundation
+
+struct EmptyCodable: Codable { }


### PR DESCRIPTION
With the messaging API some responses have empty data, which is expected. We no succeed if the data is empty but we expect it to be.

APIRequests for this case should have an EmptyCodable repsonse type