### PR TITLE
Updated request and response types for GET messages

### DIFF
--- a/treetracker-core/Networking/APIRequests/GetMessages/GetMessagesRequest.swift
+++ b/treetracker-core/Networking/APIRequests/GetMessages/GetMessagesRequest.swift
@@ -30,4 +30,30 @@ struct GetMessagesRequest: APIRequest {
             limit: limit
         )
     }
+
+    private let dateFormatter: ISO8601DateFormatter = {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [
+            .withInternetDateTime,
+            .withFractionalSeconds
+        ]
+        return dateFormatter
+    }()
+
+    var queryItemsParameterDateFormatter: ISO8601DateFormatter {
+        return dateFormatter
+    }
+
+    var responseDecoder: JSONDecoder {
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .custom({ decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+            if let date = dateFormatter.date(from: dateString) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode date string \(dateString)")
+        })
+        return jsonDecoder
+    }
 }

--- a/treetracker-core/Networking/APIRequests/GetMessages/GetMessagesResponse.swift
+++ b/treetracker-core/Networking/APIRequests/GetMessages/GetMessagesResponse.swift
@@ -9,4 +9,13 @@ import Foundation
 
 struct GetMessagesResponse: Decodable {
     let messages: [Message]
+    let links: Link
+}
+
+// MARK: - Nested Types
+extension GetMessagesResponse {
+    struct Link: Decodable {
+        let next: String?
+        let prev: String?
+    }
 }


### PR DESCRIPTION
GET messages request now overrides date formatter
GET messages response now includes links