### PR TITLE
Allow case-insensitive lookups of usernames in managedObject fetch requests during login

### DIFF
--- a/treetracker-core/Services/User/LoginService.swift
+++ b/treetracker-core/Services/User/LoginService.swift
@@ -33,6 +33,9 @@ class LocalLoginService: LoginService {
 
         let managedObjectContext = coreDataManager.viewContext
         let fetchRequest: NSFetchRequest<PlanterDetail> = PlanterDetail.fetchRequest()
+        // String comparisons are, by default, case and diacritic sensitive.
+        // [cd] within square braces specify case and diacritic insensitivity respectively.
+        // This allows to compare against username values in different cases and diacritics
         fetchRequest.predicate = NSPredicate(format: "identifier =[cd] %@", username.value)
 
         do {

--- a/treetracker-core/Services/User/LoginService.swift
+++ b/treetracker-core/Services/User/LoginService.swift
@@ -33,7 +33,7 @@ class LocalLoginService: LoginService {
 
         let managedObjectContext = coreDataManager.viewContext
         let fetchRequest: NSFetchRequest<PlanterDetail> = PlanterDetail.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "identifier == %@", username.value)
+        fetchRequest.predicate = NSPredicate(format: "identifier =[cd] %@", username.value)
 
         do {
             let planters = try managedObjectContext.fetch(fetchRequest)

--- a/treetracker-core/Services/User/SignUpService.swift
+++ b/treetracker-core/Services/User/SignUpService.swift
@@ -49,7 +49,7 @@ class LocalSignUpService: SignUpService {
 
         switch signUpDetails.username {
         case .email(let email):
-            planterDetail.email = email
+            planterDetail.email = email.lowercased()
         case .phoneNumber(let phoneNumber):
             planterDetail.phoneNumber = phoneNumber
         }


### PR DESCRIPTION
Allows case and diacritic insensitive lookup of usernames. This fixes [issue 148](https://github.com/Greenstand/treetracker-ios/issues/148)